### PR TITLE
Updating functions to load gene sets to Tribe - these include functions for comparing changes to genesets.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,18 @@ publicly available annotated sets of genes, such as Gene Ontology and Disease
 Ontology terms.
 
 
+Requirements
+------------
+
+Before you begin, make sure you have the required packages installed in your
+local Python environment.
+
+```shell
+# Run this command from the root directory of this repository, where the
+# "requirements.txt" file is.
+pip install -r requirements.txt
+```
+
 Configuration files
 -------------------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 argparse==1.2.1
 requests==2.18.4
-tribe-client>=1.1.9
+tribe-client>=1.1.11
 wsgiref==0.1.2

--- a/run_refinery.py
+++ b/run_refinery.py
@@ -150,6 +150,9 @@ def main(ini_file_path):
                 species_file, secrets_file, all_org_genesets)
 
             logger.info('Starting to save gene sets to Tribe')
+            if changed_genesets == []:
+                logger.info('Annotations have not changed in any gene sets '
+                            'for species_file %s.', species_file)
             for geneset in changed_genesets:
                 geneset['public'] = tribe_public
                 load_to_tribe(ini_file_path, geneset, tribe_token,

--- a/run_refinery.py
+++ b/run_refinery.py
@@ -117,9 +117,12 @@ def main(ini_file_path):
     if main_config_file.has_option('Tribe parameters', 'PREFER_UPDATE'):
         prefer_update = main_config_file.getboolean('Tribe parameters',
                                                     'PREFER_UPDATE')
-        tribe_url = main_config_file.get('Tribe parameters', 'TRIBE_URL')
     else:
         prefer_update = False
+
+    if main_config_file.has_option('Tribe parameters', 'TRIBE_URL'):
+        tribe_url = main_config_file.get('Tribe parameters', 'TRIBE_URL')
+    else:
         tribe_url = False
 
     species_dir = main_config_file.get('species files', 'SPECIES_DIR')

--- a/run_refinery.py
+++ b/run_refinery.py
@@ -146,14 +146,21 @@ def main(ini_file_path):
                 sys.exit(1)
 
             tribe_token = get_oauth_token(tribe_url, secrets_file)
-            changed_genesets = get_changed_genesets(
-                species_file, secrets_file, all_org_genesets)
 
-            logger.info('Starting to save gene sets to Tribe')
-            if changed_genesets == []:
-                logger.info('Annotations have not changed in any gene sets '
-                            'for species_file %s.', species_file)
-            for geneset in changed_genesets:
+            if prefer_update:
+                genesets_to_save = get_changed_genesets(
+                    species_file, secrets_file, all_org_genesets, tribe_token)
+
+                if genesets_to_save == []:
+                    logger.info('Annotations have not changed in any gene sets'
+                                ' for species_file %s.', species_file)
+            else:
+                genesets_to_save = all_org_genesets
+
+            logger.info('Starting to save %s gene sets to Tribe',
+                        len(genesets_to_save))
+
+            for geneset in genesets_to_save:
                 geneset['public'] = tribe_public
                 load_to_tribe(ini_file_path, geneset, tribe_token,
                               prefer_update=prefer_update)

--- a/species_files/human.ini
+++ b/species_files/human.ini
@@ -21,6 +21,8 @@ ASSOC_FILE_URLS: ftp://ftp.geneontology.org/go/gene-associations/goa_human.gaf.g
 
 EVIDENCE_CODES: EXP, IDA, IPI, IMP, IGI, IEP
 
+USE_SYMBOL: TRUE
+
 TAG_MAPPING_FILE: tag_mapping_files/brenda-gobp-all_mapping.dir.v2.txt
 GO_ID_COLUMN: 2
 GO_NAME_COLUMN: 3

--- a/test_files/test_main_config.ini
+++ b/test_files/test_main_config.ini
@@ -4,7 +4,7 @@ PROCESS_TO: Tribe
 
 
 [Tribe parameters]
-TRIBE_URL: http://0.0.0.0:8000
+TRIBE_URL: http://127.0.0.1:8000
 
 
 [species files]

--- a/tribe_loader.py
+++ b/tribe_loader.py
@@ -362,4 +362,4 @@ def get_changed_genesets(species_file, secrets_file, processed_genesets,
                                             proc_geneset_list)
         all_changed_genesets.extend(changed_genesets)
 
-    return changed_genesets
+    return all_changed_genesets

--- a/tribe_loader.py
+++ b/tribe_loader.py
@@ -9,6 +9,8 @@ import logging
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
+# All of these functions depend on the tribe-client package, which must be
+# installed in the same python environment where the functions are run from.
 try:
     from tribe_client.utils import obtain_token_using_credentials, \
             create_remote_geneset, create_remote_version, \
@@ -60,9 +62,6 @@ def load_to_tribe(main_config_file, geneset_info, access_token,
     tribe_secret from the secrets file defined in the main_config_file
     and the Tribe location/url from this same main_config_file.
 
-    *Note: This function depends on the tribe-client package, which must be
-    installed in the same python environment as this function is run from.
-
     Arguments:
     main_config_file -- A string, location of the main INI configuration
     file. This file should include Tribe parameters and the location of
@@ -88,7 +87,11 @@ def load_to_tribe(main_config_file, geneset_info, access_token,
                         5468: [], 6492: []},
 
         'slug': 'doid0014667-homo-sapiens'
-     }
+    }
+
+    access token -- A string. Tribe OAuth2 token returned by the
+    get_oauth_token() function above. This is required to create gene sets in
+    the desired Tribe instance.
 
     prefer_update -- Boolean keyword argument. If False, this function
     will not try to create new versions of already existing genesets - it will

--- a/tribe_loader.py
+++ b/tribe_loader.py
@@ -380,10 +380,9 @@ def get_all_changed_genesets(species_file, processed_genesets,
     genesets_by_xrid = {}
     for geneset in processed_genesets:
         key = geneset['xrdb']
-        if key in genesets_by_xrid:
-            genesets_by_xrid[key].append(geneset)
-        else:
+        if key not in genesets_by_xrid:
             genesets_by_xrid[key] = []
+        genesets_by_xrid[key].append(geneset)
 
     logger.info('The processed gene sets contain the following '
                 'cross-reference gene identifiers: %s',


### PR DESCRIPTION
This makes the step that saves the gene sets to Tribe much faster.

For human (with only the annotation files specified in species_files/human.ini):

Time to process all sets (GO, KEGG and DO): `5 minutes, 3.817 seconds`
Time to retrieve and compare all existing gene sets in Tribe with gene sets that were just processed: `18 minutes, 29.815 seconds`
Time to save all of these processed genesets to local Tribe instance (via HTTP POST requests): `2 hours, 49 minutes, 49.381 seconds`

Therefore, the time to retrieve and compare gene sets plus the time to load them (`~3 hours, 8 minutes`) is now much shorter than the previous time (`~7 hours, 9 minutes`)